### PR TITLE
Fix std::string detection hack for SetLabel.

### DIFF
--- a/include/benchmark/benchmark_api.h
+++ b/include/benchmark/benchmark_api.h
@@ -197,18 +197,6 @@ class Benchmark;
 class BenchmarkImp;
 class BenchmarkFamilies;
 
-template <class T> struct Voider {
-    typedef void type;
-};
-
-template <class T, class = void>
-struct EnableIfString {};
-
-template <class T>
-struct EnableIfString<T, typename Voider<typename T::basic_string>::type> {
-    typedef int type;
-};
-
 void UseCharPointer(char const volatile*);
 
 // Take ownership of the pointer and register the benchmark. Return the
@@ -417,13 +405,7 @@ public:
   // REQUIRES: a benchmark has exited its KeepRunning loop.
   void SetLabel(const char* label);
 
-  // Allow the use of std::string without actually including <string>.
-  // This function does not participate in overload resolution unless StringType
-  // has the nested typename `basic_string`. This typename should be provided
-  // as an injected class name in the case of std::string.
-  template <class StringType>
-  void SetLabel(StringType const & str,
-                typename internal::EnableIfString<StringType>::type = 1) {
+  void BENCHMARK_ALWAYS_INLINE SetLabel(const std::string& str) {
     this->SetLabel(str.c_str());
   }
 


### PR DESCRIPTION
Previously benchmark_api.h wasn't allowed to include standard library
headers. For this reason SetLabel had a hack to accept std::string
without including <string>. The hack worked by attempting to detect
the injected class name `basic_string`. However Clang has changed
it's behavior regarding injected class names so this hack no longer
works.

This patch removes the hack and replaces it with a function that
actually names std::string. However we still cannot pass std::string
across the dylib boundary because of libstdc++'s dual C++11 ABI.